### PR TITLE
Add support for <markdown> and <code-block> tags

### DIFF
--- a/src/components/code-block/index.js
+++ b/src/components/code-block/index.js
@@ -1,0 +1,31 @@
+var escapeXml = require('raptor-util/escapeXml');
+var hljs = require('highlight.js');
+var removeIndentation = require('src/util/remove-indentation');
+
+exports.renderer = function (data, out) {
+    if (!data.renderBody) {
+        return;
+    }
+
+    var lang = data.lang;
+
+    var body = out.captureString(function () {
+        data.renderBody(out);
+    });
+
+    body = removeIndentation(body);
+
+    if (data.wrap !== false) {
+        out.write('<pre><code class="hljs">');
+    }
+
+    if (lang) {
+        out.write(hljs.highlight(lang, body).value);
+    } else {
+        out.write(escapeXml(body));
+    }
+
+    if (data.wrap !== false) {
+        out.write('</code></pre>');
+    }
+};

--- a/src/components/code-block/marko-tag.json
+++ b/src/components/code-block/marko-tag.json
@@ -1,0 +1,6 @@
+{
+    "renderer": "./index",
+    "preserveWhitespace": true,
+    "@lang": "string",
+    "@wrap": "boolean"
+}

--- a/src/components/markdown/index.js
+++ b/src/components/markdown/index.js
@@ -1,0 +1,13 @@
+var markdownRenderer = require('src/util/markdown/markdown-renderer').render;
+
+var removeIndentation = require('src/util/remove-indentation');
+
+exports.renderer = function(input, out) {
+    var body = out.captureString(function () {
+        input.renderBody(out);
+    });
+
+	body = removeIndentation(body);
+
+    out.write(markdownRenderer(body));
+};

--- a/src/components/markdown/marko-tag.json
+++ b/src/components/markdown/marko-tag.json
@@ -1,0 +1,6 @@
+{
+    "renderer": "./index",
+    "preserveWhitespace": true,
+    "@lang": "string",
+    "@wrap": "boolean"
+}

--- a/src/util/highlight.js
+++ b/src/util/highlight.js
@@ -1,0 +1,9 @@
+var hljs = require('highlight.js');
+
+module.exports = function(code, lang) {
+    if (lang) {
+        return hljs.highlight(lang, code).value;
+    } else {
+        return hljs.highlightAuto(code).value;
+    }
+};

--- a/src/util/markdown/markdown-renderer.js
+++ b/src/util/markdown/markdown-renderer.js
@@ -3,17 +3,11 @@ var markdownAnchorName = require('./markdown-anchor-name');
 var markdownTOC = require('./markdown-toc');
 
 marked.setOptions({
-    highlight: function (code, lang) {
-        if (lang) {
-            return require('highlight.js').highlight(lang, code).value;
-        } else {
-            return require('highlight.js').highlightAuto(code).value;
-        }
-
-    }
+    highlight: require('src/util/highlight')
 });
 
 var tocRegExp = /^.*\{TOC\}.*$/im;
+
 
 exports.render = function renderMarkdown(markdown) {
 

--- a/src/util/remove-indentation.js
+++ b/src/util/remove-indentation.js
@@ -1,0 +1,51 @@
+module.exports = function(str) {
+    var lines = str.split('\n');
+    if (lines.length === 0) {
+        return '';
+    }
+
+    var indentation = 0;
+    var i;
+
+    for (i = 0; i < lines.length; i++) {
+    	var line = lines[i];
+    	var lineIndentation = 0;
+    	for (var j = 0; j < line.length; j++) {
+    		if (line.charAt(j) === ' ') {
+    			lineIndentation++;
+    		} else {
+    			break;
+    		}
+    	}
+
+    	if (lineIndentation === line.length) {
+            lines[i] = '';
+        } else if ((indentation === 0) || (lineIndentation < indentation)) {
+    		indentation = lineIndentation;
+    	}
+    }
+
+    if (indentation) {
+    	// remove all of the leading indentation
+    	for (i = 0; i < lines.length; i++) {
+    		lines[i] = lines[i].substring(indentation);
+    	}
+    }
+
+    // Check for leading and trailing empty lines
+    var begin = 0;
+    var end = lines.length;
+
+    if (lines[0].length === 0) {
+        begin++;
+    }
+
+    if (lines[end - 1].length === 0) {
+        end--;
+    }
+
+    // remove leading and trailing empty lines
+    lines = lines.slice(begin, end);
+
+    return lines.join('\n');
+};


### PR DESCRIPTION
For example:

``` xml
<code-block lang="js">
function abc(x, y, z) {
    // do something
}
</code-block>

<markdown>
# Overview
This is the overview
## This is a section
Blah blah blah.
</markdown>
```
