### PR TITLE
Fix google search URL filtering error

### DIFF
--- a/src/components/app-header/template.marko
+++ b/src/components/app-header/template.marko
@@ -17,7 +17,7 @@
                 <li class="nav-search">
                     <i class="fa fa-search" w-onclick="handleToggleSearchClick"></i>
                     <form action="https://google.com/search" method="get" class="search-form">
-                        <input type="hidden" name="q" value="site:${data.site.searchUrl || data.site.url}">
+                        <input type="hidden" name="as_sitesearch" value="${data.site.searchUrl || data.site.url}">
                         <input type="text" name="q" results="0" placeholder="" class="search-input">
                     </form>
                 </li>


### PR DESCRIPTION
I'm using El Capitan and the latest stable version of Chrome, and it seems like the current technique you're using to search the markojs.com website through google isn't working. I've added in a quick workaround: Google appends the `site: markojs.com` after the search query using a parameter called `as_sitesearch`. Looks like its now working as expected from my end :)

As a side note, I was unable to actually get the `node_modules/marko/docs` directory working to pull the documentation from as the README for this repo explained it. The `docs` directory doesn't seem to be there... did you stop shipping it with the Marko package? I just commented out `checkDocs();` while I was testing though.
