### PR TITLE
ES6 string template syntax

### DIFF
--- a/src/components/app-try-marko-app/samples/Text Replacement/Simple/template.marko
+++ b/src/components/app-try-marko-app/samples/Text Replacement/Simple/template.marko
@@ -12,4 +12,4 @@ p
     ---
 <!-- Variables/expressions inside JavaScript strings: -->
 p
-    - ${"Hello ${data.name}".toUpperCase()}
+    - ${`Hello ${data.name}`.toUpperCase()}


### PR DESCRIPTION
I guess that the intention of the sample is to convert all contents inside the quotation marks upper case. Otherwise, `<p>Hello ${data.name.toUpperCase()}</p>` is more applicable.
Then ES6 string template syntax should be used.

Or

whether the template is not compiled correctly?
Should it be compiled this way:
```
"<p>" + escapeXml(("Hello " + data.name).toUpperCase()) + "</p>"
```